### PR TITLE
add a 'bin/report.dart weekly' report

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,13 @@ Some files, notably `prs_merged_by_label` and `prs_merged`, may require light ed
 
 As of Dart 2.14, there’s an issue with a dependency of a dependency (the package `uuid`) that has yet to be properly migrated. KF6GPE hasn’t had time to fix this, and has instead chosen to pin the Dart version in `pubspec.yaml` to Dart 2.13.4. This is the version of Dart shipping with Flutter 2.2, so for the next stable release, you should be able to use that version of Dart. This and the dependency scripts may not work for you after that unless you pin the Dart version.
 
-
 The scripts occasionally time out when Github is being cranky, and you’ll see errors. Don’t panic; just go for a walk and re-run the script.
 
+## bin/report.dart
+
+This tool is a combination of sub-tools to query for github info.
+
+- `weekly`: run `dart bin/report.dart weekly` to see a report of last week's github open and closed issues
 
 ### bin/prs_landed_weekly.dart
 
@@ -128,6 +132,8 @@ to the team when the Markdown is run through
 [pandoc](https://pandoc.org/).
 
 ### bin/open_issue_count_by_week.dart
+
+Note: see also the `dart bin/report.dart weekly` command.
 
 Usage: `dart bin/open_issue_count_by_week.dart [-f from-date] [-t to-date]`
 

--- a/bin/report.dart
+++ b/bin/report.dart
@@ -1,0 +1,181 @@
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:graphql/client.dart';
+
+void main(List<String> args) async {
+  final ReportCommandRunner runner = ReportCommandRunner();
+  exit(await runner.run(args) ?? 0);
+}
+
+class ReportCommandRunner<int> extends CommandRunner {
+  ReportCommandRunner()
+      : super(
+          'report',
+          'Run various reports on the Flutter related GitHub repositories.',
+        ) {
+    addCommand(WeeklyCommand());
+  }
+
+  late GraphQLClient _client = _initGraphQLClient();
+
+  Future<QueryResult> query(QueryOptions options) {
+    return _client.query(options);
+  }
+
+  GraphQLClient _initGraphQLClient() {
+    final token = Platform.environment['GITHUB_TOKEN'];
+    if (token == null) {
+      throw 'This tool expects a github access token in the GITHUB_TOKEN '
+          'environment variable.';
+    }
+
+    final auth = AuthLink(getToken: () async => 'Bearer $token');
+    return GraphQLClient(
+      cache: GraphQLCache(),
+      link: auth.concat(HttpLink('https://api.github.com/graphql')),
+    );
+  }
+}
+
+class WeeklyCommand extends ReportCommand {
+  WeeklyCommand()
+      : super(
+          'weekly',
+          'Run a week-based report on issues opened and closed.',
+        );
+
+  Future<int> run() async {
+    final DateTime now = DateTime.now();
+    final int currentDay = now.weekday;
+    final DateTime thisWeek = now.subtract(Duration(days: currentDay - 1));
+    final DateTime lastWeek = thisWeek.subtract(Duration(days: 7));
+    final DateTime lastDay = lastWeek.add(Duration(days: 6));
+
+    const List<String> repos = [
+      'dart-lang/sdk',
+      'flutter/flutter',
+      'flutter/website',
+      'FirebaseExtended/flutterfire',
+      'googleads/googleads-mobile-flutter',
+    ];
+
+    print(
+      'Reporting from ${iso8601String(lastWeek)} '
+      'to ${iso8601String(lastDay)}:',
+    );
+
+    List<RepoInfo> infos = await Future.wait(repos.map((String repo) async {
+      return RepoInfo(
+        repo,
+        issuesOpened: await queryIssuesOpened(
+          repo: repo,
+          from: lastWeek,
+          to: lastDay,
+        ),
+        issuesClosed: await queryIssuesClosed(
+          repo: repo,
+          from: lastWeek,
+          to: lastDay,
+        ),
+      );
+    }));
+
+    for (RepoInfo info in infos) {
+      print(
+        '  ${info.repo}: '
+        '${info.issuesOpened} opened, '
+        '${info.issuesClosed} closed',
+      );
+    }
+
+    return 0;
+  }
+
+  Future<int> queryIssuesOpened({
+    required String repo,
+    required DateTime from,
+    required DateTime to,
+  }) async {
+    final queryString = '''{
+  search(query: "repo:$repo is:issue created:${iso8601String(from)}..${iso8601String(to)}", type: ISSUE, last: 100) {
+  issueCount
+    edges {
+      node {
+        ... on Issue {
+        title
+          url
+          createdAt
+          number
+          state         
+        }
+      }
+    }
+  }
+}''';
+    final result = await query(QueryOptions(document: gql(queryString)));
+
+    if (result.hasException) {
+      throw result.exception!;
+    }
+
+    return result.data!['search']['issueCount']!;
+  }
+
+  Future<int> queryIssuesClosed({
+    required String repo,
+    required DateTime from,
+    required DateTime to,
+  }) async {
+    final queryString = '''{
+  search(query: "repo:$repo is:issue is:closed closed:${iso8601String(from)}..${iso8601String(to)}", type: ISSUE, last: 100) {
+  issueCount
+    edges {
+      node {
+        ... on Issue {
+        title
+          url
+          createdAt
+          number
+          state         
+        }
+      }
+    }
+  }
+}''';
+    final result = await query(QueryOptions(document: gql(queryString)));
+
+    if (result.hasException) {
+      throw result.exception!;
+    }
+
+    return result.data!['search']['issueCount']!;
+  }
+}
+
+abstract class ReportCommand<int> extends Command {
+  final String name;
+  final String description;
+
+  ReportCommand(this.name, this.description);
+
+  Future<QueryResult> query(QueryOptions options) {
+    return (runner as ReportCommandRunner).query(options);
+  }
+}
+
+String iso8601String(DateTime date) {
+  return date.toIso8601String().substring(0, 10);
+}
+
+class RepoInfo {
+  final String repo;
+  final int issuesOpened;
+  final int issuesClosed;
+
+  RepoInfo(
+    this.repo, {
+    required this.issuesOpened,
+    required this.issuesClosed,
+  });
+}

--- a/bin/report.dart
+++ b/bin/report.dart
@@ -50,7 +50,7 @@ class WeeklyCommand extends ReportCommand {
     final int currentDay = now.weekday;
     final DateTime thisWeek = now.subtract(Duration(days: currentDay - 1));
     final DateTime lastWeek = thisWeek.subtract(Duration(days: 7));
-    final DateTime lastDay = lastWeek.add(Duration(days: 6));
+    final DateTime lastReportingDay = lastWeek.add(Duration(days: 6));
 
     const List<String> repos = [
       'dart-lang/sdk',
@@ -62,7 +62,7 @@ class WeeklyCommand extends ReportCommand {
 
     print(
       'Reporting from ${iso8601String(lastWeek)} '
-      'to ${iso8601String(lastDay)}:',
+      'to ${iso8601String(lastReportingDay)}:',
     );
 
     List<RepoInfo> infos = await Future.wait(repos.map((String repo) async {
@@ -71,12 +71,12 @@ class WeeklyCommand extends ReportCommand {
         issuesOpened: await queryIssuesOpened(
           repo: repo,
           from: lastWeek,
-          to: lastDay,
+          to: lastReportingDay,
         ),
         issuesClosed: await queryIssuesClosed(
           repo: repo,
           from: lastWeek,
-          to: lastDay,
+          to: lastReportingDay,
         ),
       );
     }));


### PR DESCRIPTION
- adds a 'bin/report.dart weekly' report

```
Run various reports on the Flutter related GitHub repositories.

Usage: report <command> [arguments]

Global options:
-h, --help    Print this usage information.

Available commands:
  weekly   Run a week-based report on issues opened and closed.

Run "report help <command>" for more information about a command.
```
