### PR TITLE
add stats reporting for dart core and dart tools packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,11 @@ The scripts occasionally time out when Github is being cranky, and you’ll see 
 
 This tool is a combination of sub-tools to query for github info.
 
-- `weekly`: run `dart bin/report.dart weekly` to see a report of last week's github open and closed issues
-- `release`: run `dart bin/report.dart release` to generate an 'issues_closed.md' file for an upcoming stable release (see the tool's help for a description of the CLI options)
+- `weekly`: run `dart bin/report.dart weekly` to see a report of last week's
+  github open and closed issues
+- `release`: run `dart bin/report.dart release` to generate an 'issues_closed.md'
+  file for an upcoming stable release (see the tool's help for a description of
+  the CLI options)
 
 ### bin/prs_landed_weekly.dart
 


### PR DESCRIPTION
- add stats reporting for dart core and dart tools packages

To the `dart bin/report.dart weekly` stats reporting, this adds:
- `--dart-core`, to show stats for the dart core (tier 1) packages
- `--dart-tools`, to show stats for the dart tools (tier 2) packages
- `--month`, to show stats on a monthly basis (instead of weekly)

Here's the new CLI:

```
Run a week-based report on issues opened and closed.

Usage: report weekly [arguments]
-h, --help                 Print this usage information.
    --dart-core            Query the Dart Ecosystem core packages.
    --dart-tools           Query the Dart Ecosystem tools packages.
    --date=<2022-01-26>    Specify the date to pull data from (defaults to the last full week).
    --month                Return stats based on calendar months (instead of weeks).
```
