### PR TITLE
add a command to generate the weekly commit rate for many dart repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,10 @@ The scripts occasionally time out when Github is being cranky, and you’ll see 
 
 This tool is a combination of sub-tools to query for github info.
 
-- `weekly`: run `dart bin/report.dart weekly` to see a report of last week's
-  github open and closed issues
-- `release`: run `dart bin/report.dart release` to generate an 'issues_closed.md'
-  file for an upcoming stable release (see the tool's help for a description of
-  the CLI options)
+- `commit-activity`: Report on the average weekly commit counts for many Dart
+   repos.
+- `release`: Generate changelog files for a stable release.
+- `weekly`: Run a week-based report on issues opened and closed.
 
 ### bin/prs_landed_weekly.dart
 


### PR DESCRIPTION
- add a command to generate the weekly commit rate for many dart repos

We'll use this info to help figure out the load on our CIs (and the review load) for auto-rolling dependencies into the dart sdk repo.