### PR TITLE
add a command to query for default branch names

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   csv:  ^5.0.0
   glob: ^2.0.1
   graphql: ^5.0.0
+  http: ^0.13.5
   intl: ^0.17.0
   lcov: ^6.0.0
   path: ^1.8.0


### PR DESCRIPTION
- add a command to query for default branch names

Running:

`dart bin/report.dart default-branch`

Will return:

```
Repository, Default branch, Stars
dart-lang/.github, main, 4
dart-lang/api.dart.dev, master, 15
dart-lang/appengine, master, 95
dart-lang/args, master, 169
...
```
