### PR TITLE
fix ci

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+# Dependabot configuration file.
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -11,12 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-
-      # Note: This workflow uses the latest stable version of the Dart SDK.
-      # You can specify other versions if desired, see documentation here:
-      # https://github.com/dart-lang/setup-dart/blob/main/README.md
-      - uses: dart-lang/setup-dart@b77f714ba35594641a83a71d243c7de39d820474
+      - uses: actions/checkout@v3
+      - uses: dart-lang/setup-dart@v1
 
       - name: Install dependencies
         run: dart pub get

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,10 +10,9 @@ dependencies:
   args: ^2.2.0
   csv:  ^5.0.0
   glob: ^2.0.1
-  graphql: ^5.0.0
+  graphql: ^5.1.3
   http: ^0.13.5
-  intl: ^0.17.0
-  lcov: ^6.0.0
+  intl: ^0.18.0
   path: ^1.8.0
   quiver: ^3.0.1
 


### PR DESCRIPTION
- use a newer version of `graphql` to address test failures on the CI
- update the action versions
- add a dependabot config in order to keep the action versions up-to-date going forward
